### PR TITLE
Reduce the size of the borders linked to the icons

### DIFF
--- a/app/src/app/navtitle/navtitle.component.sass
+++ b/app/src/app/navtitle/navtitle.component.sass
@@ -53,11 +53,13 @@ nav .nav-link
       display: none
 
 #nav-menu
+  padding: 2px 6px
   border-left: solid 1px
   @media (min-width: $breakpoint-tablet)
     display: none
 
 #nav-profil
+  padding: 2px 6px
   @media (max-width: $breakpoint-tablet)
     display: none
 


### PR DESCRIPTION
Modified the padding of the <a> tags where the menu and profile icons are located in order to reduce vertical borders.

Ticket #99