### PR TITLE
centerlise the table for small screen

### DIFF
--- a/app/src/styles.sass
+++ b/app/src/styles.sass
@@ -110,7 +110,7 @@ input
   width: 260px
   position: relative
   left: 50%
-  margin-left: calc(-1em + -130px)
+  transform: translate(-50%,0)
   padding: 1em
   border: solid 2px $maincolor
   border-radius: 8px

--- a/app/src/styles.sass
+++ b/app/src/styles.sass
@@ -107,8 +107,10 @@ input
     margin: 0
 
 .form-alone
-  width: 250px
-  margin: 0 auto
+  width: 260px
+  position: relative
+  left: 50%
+  margin-left: calc(-1em + -130px)
   padding: 1em
   border: solid 2px $maincolor
   border-radius: 8px

--- a/app/src/styles.sass
+++ b/app/src/styles.sass
@@ -107,7 +107,7 @@ input
     margin: 0
 
 .form-alone
-  width: 260px
+  width: 250px
   margin: 0 auto
   padding: 1em
   border: solid 2px $maincolor


### PR DESCRIPTION
Before the width of table was too wide (go beyond main-container) so that it is not at center, after the change, it is no bigger than main-container. So it is at the center for the screen with minimum width of 320px.
![Capture d’écran 2021-06-25 à 14 25 38](https://user-images.githubusercontent.com/83946943/123431058-24f34e80-d5c9-11eb-8e36-74d44db7480b.png)
