### PR TITLE
Move information panel inside InfoPanelComponent

### DIFF
--- a/app/src/app/poll/poll.component.html
+++ b/app/src/app/poll/poll.component.html
@@ -7,10 +7,6 @@
   Your vote has not been taken into account because the next round started while you were voting.
 </p>
 
-<app-info-panel>
-  <p>This is the message that must be displayed in the panel</p>
-</app-info-panel>
-
 <div class="information-container" *ngIf="!error">
   <div class="poll-main" *ngIf="!!answer else loadingTmpl">
 
@@ -90,98 +86,86 @@
 
   </div>
 
-  
-  <div class="info-panel opened">
-    <div class="info-panel-icon">
-      <mat-icon id="help-button">help</mat-icon>
-    </div>
-      
-    <div class="info-panel-icon">
-      <mat-icon id="close-button">close</mat-icon>
-    </div>
-    <div class="info-panel-content">
-      <div class="information" *ngIf="!!answer">
-      
-        <ng-template #firstRoundTmpl>
-          <p i18n>
-            This is the first round of the poll.
-            <ng-container *ngIf="!hasCurrentRoundBallot()">
-              You can submit a first ballot, in which case you will become a participant of the poll.
-            </ng-container>
-            In the next rounds, you will be able to change your vote, based on the results of the previous round.
-            The first round will end
-            <ng-container [ngSwitch]="roundDeadlinePassed()">
-              <ng-container *ngSwitchCase="true">
-                as soon as three participants have voted.
-              </ng-container>
-              <ng-container *ngSwitchCase="false">
-                {{ answer.RoundDeadline | nearDate:'inside' }}.
-              </ng-container>
-            </ng-container>
-            <ng-container *ngIf="!hasCurrentRoundBallot()">
-              It will not be possible to join the poll once the first round has ended.
-            </ng-container>
-            Then, each round will last {{ answer.MaxRoundDuration | duration }}, or until all participants have voted,
-            whichever comes first.
-          </p>
-        </ng-template>
-  
-        <ng-container [ngSwitch]="answer.State">
-          <ng-container *ngSwitchCase="'Waiting'">
-            <p i18n>
-              The poll will start {{ answer.Start | nearDate:'inside' }}.
-              You won't be able to vote until that date.
-            </p>
+  <app-info-panel *ngIf="!!answer">
+    
+    <ng-template #firstRoundTmpl>
+      <p i18n>
+        This is the first round of the poll.
+        <ng-container *ngIf="!hasCurrentRoundBallot()">
+          You can submit a first ballot, in which case you will become a participant of the poll.
+        </ng-container>
+        In the next rounds, you will be able to change your vote, based on the results of the previous round.
+        The first round will end
+        <ng-container [ngSwitch]="roundDeadlinePassed()">
+          <ng-container *ngSwitchCase="true">
+            as soon as three participants have voted.
           </ng-container>
-          <ng-container *ngSwitchCase="'Terminated'">
-            <p i18n>
-              Votes are now closed for this poll.
-              The displayed result is the final one.
-            </p>
-          </ng-container>
-          <ng-container *ngSwitchCase="'Active'">
-            <p *ngIf="answer.CurrentRound > 0 else firstRoundTmpl" i18n>
-              This is the {{ answer.CurrentRound + 1 | ordinal }} round of the poll.
-              You can now change your vote, based on the result of the previous round.
-              If you do not vote before the end of the round,
-              <ng-container [ngSwitch]="answer.CarryForward">
-                <ng-container *ngSwitchCase="false">
-                  you will be declared abstentionist.
-                </ng-container>
-                <ng-container *ngSwitchCase="true">
-                  your previous vote will be carried forward.
-                </ng-container>
-              </ng-container>
-              The round will end {{ answer.RoundDeadline | nearDate:'inside' }} or when all participants have voted,
-              whichever comes first.
-            </p>
-  
-            <p i18n>
-              The poll will end after
-              <ng-container [ngSwitch]="pollEndCase()">
-                <ng-container *ngSwitchCase="'current'">
-                  the current round.
-                </ng-container>
-                <ng-container *ngSwitchCase="'deadlinePassed'">
-                  the {{ answer.MinNbRounds | ordinal }} round.
-                </ng-container>
-                <ng-container *ngSwitchCase="'minExceeded'">
-                  the {{ answer.MaxNbRounds | ordinal }} round, or
-                  {{ answer.PollDeadline | nearDate:'inside' }}, wichever comes first.
-                </ng-container>
-                <ng-container *ngSwitchCase="'full'">
-                  the {{ answer.MaxNbRounds | ordinal }} round, or
-                  after the {{ answer.MinNbRounds | ordinal }} round
-                  if that happens after {{ answer.PollDeadline | nearDate:'noPrep' }}.
-                </ng-container>
-              </ng-container>
-            </p>
+          <ng-container *ngSwitchCase="false">
+            {{ answer.RoundDeadline | nearDate:'inside' }}.
           </ng-container>
         </ng-container>
-  
-      </div>
-    </div>
-  </div>
+        <ng-container *ngIf="!hasCurrentRoundBallot()">
+          It will not be possible to join the poll once the first round has ended.
+        </ng-container>
+        Then, each round will last {{ answer.MaxRoundDuration | duration }}, or until all participants have voted,
+        whichever comes first.
+      </p>
+    </ng-template>
+
+    <ng-container [ngSwitch]="answer.State">
+      <ng-container *ngSwitchCase="'Waiting'">
+        <p i18n>
+          The poll will start {{ answer.Start | nearDate:'inside' }}.
+          You won't be able to vote until that date.
+        </p>
+      </ng-container>
+      <ng-container *ngSwitchCase="'Terminated'">
+        <p i18n>
+          Votes are now closed for this poll.
+          The displayed result is the final one.
+        </p>
+      </ng-container>
+      <ng-container *ngSwitchCase="'Active'">
+        <p *ngIf="answer.CurrentRound > 0 else firstRoundTmpl" i18n>
+          This is the {{ answer.CurrentRound + 1 | ordinal }} round of the poll.
+          You can now change your vote, based on the result of the previous round.
+          If you do not vote before the end of the round,
+          <ng-container [ngSwitch]="answer.CarryForward">
+            <ng-container *ngSwitchCase="false">
+              you will be declared abstentionist.
+            </ng-container>
+            <ng-container *ngSwitchCase="true">
+              your previous vote will be carried forward.
+            </ng-container>
+          </ng-container>
+          The round will end {{ answer.RoundDeadline | nearDate:'inside' }} or when all participants have voted,
+          whichever comes first.
+        </p>
+
+        <p i18n>
+          The poll will end after
+          <ng-container [ngSwitch]="pollEndCase()">
+            <ng-container *ngSwitchCase="'current'">
+              the current round.
+            </ng-container>
+            <ng-container *ngSwitchCase="'deadlinePassed'">
+              the {{ answer.MinNbRounds | ordinal }} round.
+            </ng-container>
+            <ng-container *ngSwitchCase="'minExceeded'">
+              the {{ answer.MaxNbRounds | ordinal }} round, or
+              {{ answer.PollDeadline | nearDate:'inside' }}, wichever comes first.
+            </ng-container>
+            <ng-container *ngSwitchCase="'full'">
+              the {{ answer.MaxNbRounds | ordinal }} round, or
+              after the {{ answer.MinNbRounds | ordinal }} round
+              if that happens after {{ answer.PollDeadline | nearDate:'noPrep' }}.
+            </ng-container>
+          </ng-container>
+        </p>
+      </ng-container>
+    </ng-container>
+
+  </app-info-panel>
  
 </div>  
 

--- a/app/src/app/shared/info-panel/info-panel.component.html
+++ b/app/src/app/shared/info-panel/info-panel.component.html
@@ -1,6 +1,9 @@
-<div class="pollInfo" [ngClass]="{'opened': showInfo, 'closed': !showInfo}">
-  <button mat-icon-button type="button" (click)="showInfo=!showInfo">
-    <mat-icon>{{ showInfo ? 'help' : 'help_outline' }}</mat-icon>
-  </button>
-  <ng-content *ngIf="showInfo"></ng-content>
+<button class="info-panel-icon" (click)="showInfo = !showInfo">
+  <mat-icon class="help-button">help</mat-icon>
+  <mat-icon class="close-button">close</mat-icon>
+</button>
+<div class="info-panel-content">
+  <div class="info-panel-inner information">
+    <ng-content></ng-content>
+  </div>
 </div>

--- a/app/src/app/shared/info-panel/info-panel.component.sass
+++ b/app/src/app/shared/info-panel/info-panel.component.sass
@@ -1,0 +1,53 @@
+@use 'sass:color'
+@import '../../../responsive'
+@import '../../../sizes'
+
+:host
+  border: 1px solid #704f6a
+  border-right: none
+  background-color: #d5b6d0
+  box-shadow: -5px 0px 5px 0 rgba(255, 204, 244, 0.7)
+  position: absolute
+  z-index: 1
+  right: 0
+  display: flex
+  flex-flow: row nowrap
+  transition: width 2s
+  .info-panel-icon
+    background: transparent
+    border: none
+    padding: 0
+    height: min-content
+    mat-icon
+      margin: 0.7em $small-space
+  $menu-close-width: 32px
+  $width-smartphone: 80vw
+  $width-tablet: 50vw
+  min-width: $menu-close-width
+  max-width: $width-smartphone
+  @media screen and (min-width: $breakpoint-tablet) and (max-width: $breakpoint-laptop)
+    min-width: $menu-close-width
+    max-width: $width-tablet
+  @media screen and (min-width: $breakpoint-laptop)
+    display: none
+  &.opened
+    .info-panel-icon .help-button
+      display: none
+    width: $width-smartphone
+    @media screen and (min-width: $breakpoint-tablet) and (max-width: $breakpoint-laptop)
+      width: $width-tablet
+  &.closed
+    .info-panel-icon .close-button
+      display: none
+    width: $menu-close-width  
+  .info-panel-content
+    overflow: hidden
+  .info-panel-content .information
+    margin: 0
+    padding: 0
+    border: none
+    width: calc(#{$width-smartphone} - #{$menu-close-width})
+    @media screen and (min-width: $breakpoint-tablet) and (max-width: $breakpoint-laptop)
+      width: calc(#{$width-tablet} - #{$menu-close-width})
+    p
+      margin-top: 1em

--- a/app/src/app/shared/info-panel/info-panel.component.ts
+++ b/app/src/app/shared/info-panel/info-panel.component.ts
@@ -1,5 +1,5 @@
 // Itero - Online iterative vote application
-// Copyright (C) 2020 Wan JIN
+// Copyright (C) 2021 Wan JIN, Joseph Boudou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-import { Component, OnInit } from '@angular/core';
+import { Component, HostBinding, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-info-panel',
@@ -23,6 +23,10 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./info-panel.component.sass']
 })
 export class InfoPanelComponent implements OnInit {
+
+  @HostBinding('class') get stateClass() {
+    return this.showInfo ? 'opened' : 'closed'
+  }
 
   showInfo: boolean = false;
 

--- a/app/src/styles.sass
+++ b/app/src/styles.sass
@@ -1,9 +1,9 @@
 @use 'sass:color'
 @import 'colors'
-@import 'typo'
-@import 'sizes'
 @import 'mixins'
 @import 'responsive'
+@import 'sizes'
+@import 'typo'
 
 body
   font-family: "Asap", sans-serif
@@ -152,52 +152,6 @@ $itero-mat-accent: mat-palette($itero-mat-maincolor, A400, A200, A700)
 $itero-mat-theme: mat-light-theme(( color: ( primary: $itero-mat-primary, accent: $itero-mat-accent )))
 @include angular-material-theme($itero-mat-theme)
 @include angular-material-typography($itero-mat-typography)
-
-
-.info-panel
-  border: 1px solid #704f6a
-  border-right: none
-  background-color: #d5b6d0
-  box-shadow: -5px 0px 5px 0 rgba(255, 204, 244, 0.7)
-  position: absolute
-  z-index: 1
-  right: 0
-  display: flex
-  flex-flow: row nowrap
-  transition: width 2s
-  .info-panel-icon mat-icon
-    margin: 0.7em $small-space
-  $menu-close-width: 32px
-  $width-smartphone: 80vw
-  $width-tablet: 50vw
-  min-width: $menu-close-width
-  max-width: $width-smartphone
-  @media screen and (min-width: $breakpoint-tablet) and (max-width: $breakpoint-laptop)
-    min-width: $menu-close-width
-    max-width: $width-tablet
-  @media screen and (min-width: $breakpoint-laptop)
-    display: none
-  &.opened
-    #help-button
-      display: none
-    width: $width-smartphone
-    @media screen and (min-width: $breakpoint-tablet) and (max-width: $breakpoint-laptop)
-      width: $width-tablet
-  &.closed
-    #close-button
-      display: none
-    width: $menu-close-width  
-  .info-panel-content
-    overflow: hidden
-  .info-panel-content .information
-    margin: 0
-    padding: 0
-    border: none
-    width: calc(#{$width-smartphone} - #{$menu-close-width})
-    @media screen and (min-width: $breakpoint-tablet) and (max-width: $breakpoint-laptop)
-      width: calc(#{$width-tablet} - #{$menu-close-width})
-    p
-      margin-top: 1em
 
 
 .basicform mat-select


### PR DESCRIPTION
 - Move the HTML structure and the SASS code from PollComponent to InfoPanelComponent.
 - In PollComponent, the structure is replaced with app-info-panel.
 - Group the buttons in the same element. Change that element to be a button.
 - Remove the useless outer div. The opened/closed classes are added directly to the app-info-panel element using `@HostBinding`.

Closes #113